### PR TITLE
build(nix): refactor to allow building without the use of flakes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,11 +1,15 @@
 {
-  lib,
-  system,
-  naersk,
+  pkgs ? import <nixpkgs> {},
+  lib ? pkgs.lib,
+  system ? pkgs.system,
+  naersk ? pkgs.callPackage (builtins.fetchTarball {
+    url = "https://github.com/nix-community/naersk/archive/8507af04eb40c5520bd35d9ce6f9d2342cea5ad1.tar.gz";
+    sha256 = "sha256:0x024pcj1jwnsdx2lkm12q9zclmrsd74xrvghb2a4qjjnsvywx4d";
+  }) {},
 }: let
   manifest = (lib.importTOML ./Cargo.toml).package;
 in
-  naersk.lib."${system}".buildPackage {
+  naersk.buildPackage {
     inherit (manifest) version;
     pname = manifest.name;
     root = lib.cleanSource ./.;

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
   in {
     overlays = rec {
       default = final: prev: {
-        bellado = prev.callPackage ./. {inherit naersk;};
+        bellado = prev.callPackage ./. {naersk = naersk.lib."${prev.system}";};
       };
     };
 


### PR DESCRIPTION
This changes the default.nix file to use fetchTarball to pull naersk when using `nix-build` rather than via flakes