### PR TITLE
refactor: move to clap 'derive' feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384e169cc618c613d5e3ca6404dda77a8685a63e08660dcc64abaf7da7cb0c7a"
 dependencies = [
  "clap_builder",
+ "clap_derive",
+ "once_cell",
 ]
 
 [[package]]
@@ -140,6 +142,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -212,6 +226,12 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,6 @@ repository = "https://github.com/isabelroses/bellado"
 
 [dependencies]
 chrono = "0.4.26"
-clap = "4.3.9"
+clap = { version = "4.3.9", features = [ "derive" ] }
 dirs = "5.0.1"
 serde_json = "1.0.99"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,80 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Debug, Parser)]
+#[command(name = "bellado")]
+#[command(about = "A fast and simple cli todo tool", long_about = None, arg_required_else_help = true)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Commands {
+    /// Create the reqired files
+    #[command(arg_required_else_help = true)]
+    Init {},
+    /// Create a new task
+    #[command(arg_required_else_help = true, short_flag = 'a')]
+    Add {
+        /// The task you wish to create
+        task: String,
+        #[arg(short = 'c')]
+
+        /// The category for the task you wish to create
+        #[arg(required = true)]
+        categories: Vec<String>,
+    },
+    /// List out tasks
+    #[command(arg_required_else_help = true, short_flag = 'l')]
+    List {
+        /// Show all tasks
+        #[arg(short = 'a')]
+        all: bool,
+
+        /// Show completed tasks
+        #[arg(short = 'c', conflicts_with = "all")]
+        complete: bool,
+
+        /// Show tasks that match the given categories
+        #[arg(short = 's', conflicts_with = "all")]
+        categories: Vec<String>
+    },
+    /// Output the JSON file
+    #[command(arg_required_else_help = true, short_flag = 'j')]
+    Json {
+        /// Display the JSON in a pretty format
+        #[arg(short = 'p')]
+        pretty: bool,
+    },
+    /// Mark task(s) as completed
+    #[command(arg_required_else_help = true, short_flag = 'c')]
+    Complete {
+        /// Task(s) to mark as completed
+        #[arg(required = true)]
+        task_ids: Vec<u64>
+    },
+    /// Delete task(s)
+    #[command(arg_required_else_help = true, short_flag = 'd')]
+    Delete {
+        /// Task(s) to delete
+        #[arg(required = true)]
+        task_ids: Vec<u64>
+    },
+    /// Edit the description of task
+    #[command(arg_required_else_help = true, short_flag = 'e')]
+    Edit {
+        /// The ID of the task you wish to get
+        task: u64,
+        /// The new description
+        description: String
+    },
+    /// Delete all tasks
+    #[command(arg_required_else_help = true, short_flag = 'C')]
+    Clear { },
+    /// Get a task by ID
+    #[command(arg_required_else_help = true, short_flag = 'g')]
+    Get {
+        /// The ID of the task you wish to edit
+        task: u64,
+    }
+}


### PR DESCRIPTION
This refactors the argument declarations into a struct / enum that utilises the clap "derive" api. This also gets clap to do the number parsing on the task ID arguments, instead of doing that ourselves.