### PR TITLE
Pin Rust to v1.70.0 (latest stable version) in rust-toolchain.toml

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,11 +1,24 @@
 {
-  pkgs ? import <nixpkgs> {},
+  pkgs ? import <nixpkgs> {
+    overlays = [
+      (import (builtins.fetchTarball {
+        url = "https://github.com/oxalica/rust-overlay/archive/c3e43223dece545cfe06ddd92fd782adc73d56c3.tar.gz";
+        sha256 = "sha256-wOmpZis06pVKTR+5meGwhrW10/buf98lnA26uQLaqek=";
+      }))
+    ];
+  },
   lib ? pkgs.lib,
   system ? pkgs.system,
-  naersk ? pkgs.callPackage (builtins.fetchTarball {
-    url = "https://github.com/nix-community/naersk/archive/8507af04eb40c5520bd35d9ce6f9d2342cea5ad1.tar.gz";
-    sha256 = "sha256:0x024pcj1jwnsdx2lkm12q9zclmrsd74xrvghb2a4qjjnsvywx4d";
-  }) {},
+  naersk ? (
+    let toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml; in
+    pkgs.callPackage (builtins.fetchTarball {
+      url = "https://github.com/nix-community/naersk/archive/8507af04eb40c5520bd35d9ce6f9d2342cea5ad1.tar.gz";
+      sha256 = "sha256-jXTut7ZSYqLEgm/nTk7TuVL2ExahTip605bLINklAnQ=";
+    }) {
+      cargo = toolchain;
+      rustc = toolchain;
+    }
+  ),
 }: let
   manifest = (lib.importTOML ./Cargo.toml).package;
 in

--- a/flake.lock
+++ b/flake.lock
@@ -39,7 +39,24 @@
     "root": {
       "inputs": {
         "naersk": "naersk",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1688438033,
+        "narHash": "sha256-wOmpZis06pVKTR+5meGwhrW10/buf98lnA26uQLaqek=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "c3e43223dece545cfe06ddd92fd782adc73d56c3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -7,42 +7,53 @@
       url = "github:nix-community/naersk";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      flake = false;
+    };
   };
 
   outputs = {
     self,
     nixpkgs,
-    naersk,
-  }: let
-    inherit (nixpkgs.lib) genAttrs systems;
-    forAllSystems = genAttrs systems.flakeExposed;
-    pkgsFor = forAllSystems (system:
-      import nixpkgs {
-        inherit system;
-        overlays = [self.overlays.default];
-      });
-  in {
+    ...
+  } @ inputs: let
+    forAllSystems = nixpkgs.lib.genAttrs ["x86_64-linux" "x86_64-darwin" "i686-linux" "aarch64-linux" "aarch64-darwin"];
+    pkgs = system: (import nixpkgs {
+      inherit system;
+      overlays = [
+        (import inputs.rust-overlay)
+      ];
+    });
+    toolchain = system: (pkgs system).rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+    naersk = system: let
+      toolchain' = toolchain system;
+    in
+      (pkgs system).callPackage inputs.naersk {
+        cargo = toolchain';
+        rustc = toolchain';
+      };
+  in rec {
+    packages = forAllSystems (system: rec {
+      bellado = (pkgs system).callPackage ./. {
+        naersk = (naersk system).lib.${system};
+      };
+      default = bellado;
+    });
+
+    # For `nix develop` (optional, can be skipped):
+    devShells = forAllSystems (system: rec {
+      bellado = (pkgs system).mkShell {
+        nativeBuildInputs = [(toolchain system)];
+      };
+      default = bellado;
+    });
+
     overlays = rec {
-      default = final: prev: {
-        bellado = prev.callPackage ./. {naersk = naersk.lib."${prev.system}";};
+      bellado = final: prev: {
+        bellado = self.packages.${prev.system}.bellado;
       };
+      default = bellado;
     };
-
-    packages = forAllSystems (s: let
-      pkgs = pkgsFor.${s};
-    in rec {
-      inherit (pkgs) bellado;
-      default = bellado;
-    });
-
-    devShells = forAllSystems (s: let
-      pkgs = pkgsFor.${s};
-    in rec {
-      bellado = pkgs.mkShell {
-        inputsFrom = [pkgs.bellado];
-        buildInputs = with pkgs; [rustc rust-analyzer cargo rustfmt clippy];
-      };
-      default = bellado;
-    });
   };
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.70.0" # Latest stable as of 2023-07-04
+components = [ "rustfmt", "rustc", "clippy", "rust-analyzer" ]


### PR DESCRIPTION
This makes it so both nix and rustup users will be using the same version of rust, rust-analyzer, clippy, and so on