### PR TITLE
refactor: separate data operations; add serde derive; add error propagation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 /.vscode
+.direnv/
+.envrc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,9 +82,11 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 name = "bellado"
 version = "0.1.2"
 dependencies = [
+ "anyhow",
  "chrono",
  "clap",
  "dirs",
+ "serde",
  "serde_json",
 ]
 
@@ -87,6 +95,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "bumpalo"
@@ -235,9 +249,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "iana-time-zone"
@@ -263,33 +277,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
 dependencies = [
  "hermit-abi",
- "io-lifetimes",
  "rustix",
  "windows-sys",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
 
 [[package]]
 name = "js-sys"
@@ -302,15 +304,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "log"
@@ -341,18 +343,18 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -363,7 +365,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -379,13 +381,12 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.20"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
+checksum = "aabcb0461ebd01d6b79945797c27f8529082226cb630a9865a71870ff63532a4"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.3",
  "errno",
- "io-lifetimes",
  "libc",
  "linux-raw-sys",
  "windows-sys",
@@ -393,15 +394,29 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "d01b7404f9d441d3ad40e6a636a7782c377d2abdbe4fa2440e2edcc2f4f10db8"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.166"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd83d6dde2b6b2d466e14d9d1acce8816dedee94f735eac6395808b3483c6d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"
@@ -422,9 +437,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -464,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
 
 [[package]]
 name = "utf8parse"
@@ -582,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,5 @@ chrono = "0.4.26"
 clap = { version = "4.3.9", features = [ "derive" ] }
 dirs = "5.0.1"
 serde_json = "1.0.99"
+serde = { version =  "1.0.99", features = [ "derive" ] }
+anyhow = "1.0.71"

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,0 +1,33 @@
+use std::{path::PathBuf, fs};
+use chrono::{DateTime, Local};
+use anyhow::{Result, Context};
+
+use crate::tasks::Store;
+
+pub fn get_datastore_file() -> Result<PathBuf> {
+    let docs_todo = dirs::document_dir().context("document dir could not be found")?.join("todo.json");
+    let local_todo = dirs::data_local_dir().context("data dir could not be found")?.join("belldo/todo.json");
+
+    if docs_todo.exists() {
+        Ok(docs_todo)
+    } else if local_todo.exists() {
+        Ok(local_todo.join("todo.json"))
+    } else {
+        eprintln!("Error: No todo file found");
+        eprintln!("Please run `bellado init` to create the required files");
+        std::process::exit(1);
+    }
+}
+
+pub fn create_files(path: PathBuf) -> Result<()> {
+    let prefix = path.parent().with_context(|| format!("no parent for path {}", path.display()))?;
+    fs::create_dir_all(prefix)?;
+    let store = Store { tasks: vec![] };
+    fs::write(&path, serde_json::to_string_pretty(&store)?)?;
+    Ok(())
+}
+
+pub fn get_time_string() -> Result<String> {
+    let local: DateTime<Local> = Local::now();
+    Ok(local.format("%H:%M %d/%m/%Y").to_string())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,321 +1,133 @@
-use chrono::{DateTime, Local};
+use anyhow::{Context, Result};
 use clap::Parser;
 use dirs;
 use serde_json;
-use std::{
-    collections::HashSet,
-    fs::{self, File},
-    io::{self, Write},
-    path::PathBuf,
-};
+use std::io::{stdin, stdout, BufWriter, Write};
 
 mod cli;
+mod io;
+mod tasks;
 use cli::{Cli, Commands};
 
 fn main() {
     let args = Cli::parse();
     println!("{:?}", args);
 
-    match args.command {
-        Commands::Init { } => {
-            init();
-        }
-        Commands::List { all, complete, categories } => {
-            list_tasks(all, complete, categories);
-        }
-        Commands::Json { pretty } => {
-            display_json(pretty);
-        }
-        Commands::Add { task, categories } => {
-            create_task(task, categories);
-        }
-        Commands::Complete { task_ids } => {
-            toggle_completed(task_ids);
-        }
-        Commands::Delete { task_ids } => {
-            delete_tasks(task_ids);
-        }
-        Commands::Edit { task, description } => {
-            edit_task(task, description);
-        }
-        Commands::Clear {  } => {
-            clear_tasks();
-        }
-        Commands::Get { task } => {
-            get_task(task);
-        }
-        _ => {
-            println!("Error: invalid command");
-            std::process::exit(1);
-        }
-    }
-}
-
-// get file related functions
-fn get_file() -> PathBuf {
-    let docs_todo = dirs::document_dir().unwrap().join("todo.json");
-    let local_todo = dirs::data_local_dir().unwrap().join("belldo/todo.json");
-
-    if docs_todo.exists() {
-        docs_todo
-    } else if local_todo.exists() {
-        local_todo.join("todo.json")
-    } else {
-        println!("Error: No todo file found");
-        println!("Please run `bellado init` to create the required files");
-        std::process::exit(1);
-    }
-}
-
-fn load_json(path: &PathBuf) -> serde_json::Value {
-    let file = File::open(&path).expect("Unable to read file");
-    let reader = io::BufReader::new(file);
-    serde_json::from_reader(reader).expect("Failed to parse JSON")
-}
-
-fn save_json(filename: &PathBuf, json: &serde_json::Value) {
-    let file = File::create(filename).expect("Failed to create file");
-    let writer = std::io::BufWriter::new(file);
-    serde_json::to_writer_pretty(writer, json).expect("Failed to write JSON")
-}
-
-// set the json file location
-fn init() {
-    if get_file().exists() {
-        println!("Tasks file already exists.");
-        return;
-    }
-    let docs_todo = dirs::document_dir().unwrap().join("todo.json");
-    let local_todo = dirs::data_local_dir().unwrap().join("belldo/todo.json");
-
-    println!("Where would you like to save the todo file");
-    println!("(1) {}", docs_todo.display());
-    println!("(2) {}", local_todo.display());
-
-    let mut inp = String::new();
-    io::stdin()
-        .read_line(&mut inp)
-        .expect("Error: Failed to read line");
-
-    let inp: i32 = inp.trim().parse().expect("Error: Input not an integer");
-    match inp {
-        1 => create_files(docs_todo),
-        2 => create_files(local_todo),
-        _ => println!("Error: not an option"),
-    }
-}
-
-fn create_files(path: PathBuf) {
-    let prefix = path.parent().unwrap();
-    fs::create_dir_all(prefix).unwrap();
-    fs::write(&path, b"{\"tasks\": []}").expect("Error: failed to write to file");
-}
-
-fn display_json(pretty: bool) {
-    let json_loc = get_file();
-    let json = load_json(&json_loc);
-    if pretty {
-        println!("{}", serde_json::to_string_pretty(&json).unwrap());
-    } else {
-        println!("{}", json);
-    }
-}
-
-fn list_tasks(show_all: bool, show_complete: bool, categories: Vec<String>) {
-    let json_loc = get_file();
-    let json = load_json(&json_loc);
-    let tasks = json["tasks"].as_array().unwrap();
-
-    let category_set: HashSet<_> = categories.into_iter().collect();
-
-    for task in tasks {
-        let completed = task["completed"].as_bool().unwrap();
-        if show_all {
-            show_user(task, true, true, true, true, true, true);
-            continue;
-        }
-        if !category_set.is_empty() {
-            let task_categories = task["categories"].as_array().unwrap();
-            let has_matching_category = task_categories
-                .iter()
-                .any(|category| category_set.contains(&category.as_str().unwrap().to_string()));
-
-            if has_matching_category {
-                if !completed && !show_complete {
-                    show_user(task, true, true, true, false, false, false);
-                    continue;
+    fn handle_command(args: Cli) -> Result<()> {
+        match args.command {
+            Commands::Init {} => {
+                let datastore_file = io::get_datastore_file()?;
+                if datastore_file.exists() {
+                    eprint!("Data file {} already exists", datastore_file.display());
+                    return Ok(());
                 }
-                if show_complete {
-                    show_user(task, true, true, true, false, true, true);
+
+                let docs_todo = dirs::document_dir()
+                    .context("document dir could not be found")?
+                    .join("todo.json");
+
+                let local_todo = dirs::data_local_dir()
+                    .context("data dir could not be found")?
+                    .join("belldo/todo.json");
+
+                println!("Where would you like to save the todo file");
+                println!("(1) {}", docs_todo.display());
+                println!("(2) {}", local_todo.display());
+
+                let mut inp = String::new();
+                stdin()
+                    .read_line(&mut inp)
+                    .context("could not read line from stdin")?;
+
+                let location_choice = inp
+                    .trim()
+                    .parse::<i32>()
+                    .context("input was not a number")?;
+
+                match location_choice {
+                    1 => io::create_files(docs_todo)?,
+                    2 => io::create_files(local_todo)?,
+                    _ => println!("Error: not an option"),
+                };
+            }
+            Commands::List {
+                all,
+                complete,
+                categories,
+            } => {
+                let tasks = tasks::get_all(all, complete, categories)?;
+                for task in tasks {
+                    display_task(task)?;
                 }
             }
-            continue;
-        }
-        if !completed && !show_complete {
-            show_user(task, true, true, false, false, false, false);
-            continue;
-        }
-        if show_complete {
-            show_user(task, true, true, false, false, true, true);
-        }
-    }
-}
-
-fn get_task(id: u64) {
-    let json_loc = get_file();
-    let json = load_json(&json_loc);
-    let tasks = json["tasks"].as_array().unwrap();
-
-    for task in tasks {
-        if let Some(task_id) = task.get("id").and_then(serde_json::Value::as_u64) {
-            if task_id == id {
-                show_user(task, true, true, true, true, true, true);
-            }
-        }
-    }
-}
-
-fn show_user(
-    inp: &serde_json::Value,
-    id: bool,
-    text: bool,
-    category: bool,
-    created_at: bool,
-    completed_at: bool,
-    completed: bool,
-) {
-    let stdout = io::stdout();
-    let mut handle = io::BufWriter::new(stdout);
-    if completed {
-        if inp["completed"].as_bool() == Some(true) {
-            write!(handle, "✓ ").expect("Failed to write to stdout");
-        } else {
-            write!(handle, "✗ ").expect("Failed to write to stdout");
-        }
-    }
-    if id {
-        write!(handle, "{} ", inp["id"]).expect("Failed to write to stdout");
-    }
-    if text {
-        write!(handle, "{} ", inp["text"]).expect("Failed to write to stdout");
-    }
-    if category {
-        let categories = inp["categories"]
-            .as_array()
-            .map(|categories| {
-                categories
-                    .iter()
-                    .map(|category| category.as_str().unwrap())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            })
-            .unwrap_or_else(|| String::new());
-        if !categories.is_empty() {
-            write!(handle, "[{}] ", categories).expect("Failed to write to stdout");
-        }
-    }
-    if created_at {
-        write!(handle, "{} ", inp["created_at"]).expect("Failed to write to stdout");
-    }
-    if completed_at {
-        write!(handle, "{} ", inp["completed_at"]).expect("Failed to write to stdout");
-    }
-    handle.write_all(b"\n").unwrap();
-    handle.flush().unwrap();
-}
-
-fn create_task(inp: String, categories: Vec<String>) {
-    let mut json = load_json(&get_file());
-    let tasks = json
-        .get_mut("tasks")
-        .expect("Failed to parse tasks")
-        .as_array_mut()
-        .expect("Failed to parse tasks");
-    let next_id = tasks.last().map_or(0, |task| task["id"].as_u64().unwrap()) + 1;
-
-    let new_task = serde_json::json!({
-        "id": next_id,
-        "text": inp.to_string(),
-        "categories": categories,
-        "created_at": get_time(),
-        "completed_at": "N/A",
-        "completed": false
-    });
-
-    tasks.push(new_task);
-    save_json(&get_file(), &json);
-}
-
-fn toggle_completed(task_ids: Vec<u64>) {
-    let mut json = load_json(&get_file());
-    let tasks = json
-        .get_mut("tasks")
-        .expect("Failed to parse tasks")
-        .as_array_mut()
-        .expect("Failed to parse tasks");
-
-    for task in tasks.iter_mut() {
-        if let Some(id) = task.get("id").and_then(serde_json::Value::as_u64) {
-            if task_ids.contains(&id) {
-                let complete = task["completed"].as_bool().unwrap();
-                task["completed"] = serde_json::json!(!complete);
-                if !complete {
-                    task["completed_at"] = serde_json::json!(get_time());
+            Commands::Json { pretty } => {
+                let store = &tasks::load(&io::get_datastore_file()?)?;
+                if pretty {
+                    println!("{}", serde_json::to_string_pretty(store)?);
                 } else {
-                    task["completed_at"] = serde_json::json!("N/A");
+                    println!("{}", serde_json::to_string(store)?);
+                }
+            }
+            Commands::Add { task, categories } => {
+                tasks::create(task, categories)?;
+            }
+            Commands::Complete { task_ids } => {
+                for task in task_ids {
+                    tasks::toggle_completion(task)?;
+                }
+            }
+            Commands::Delete { task_ids } => {
+                tasks::delete(task_ids)?;
+            }
+            Commands::Edit { task, description } => {
+                tasks::edit(task, description)?;
+            }
+            Commands::Clear {} => {
+                tasks::reset()?;
+            }
+            Commands::Get { task } => {
+                let fetched_task = tasks::get(task)?;
+                if let Some(task) = fetched_task {
+                    display_task(task)?;
+                } else {
+                    println!("No task found with ID {task}");
                 }
             }
         }
+
+        Ok(())
     }
 
-    save_json(&get_file(), &json);
+    let result = handle_command(args);
+
+    if let Err(error) = result {
+        eprint!("Error running commands: {:?}", error);
+    }
 }
 
-fn delete_tasks(task_ids: Vec<u64>) {
-    let mut json = load_json(&get_file());
-    let tasks = json
-        .get_mut("tasks")
-        .expect("Failed to parse tasks")
-        .as_array_mut()
-        .expect("Failed to parse tasks");
-
-    tasks.retain(|task| {
-        if let Some(id) = task.get("id").and_then(serde_json::Value::as_u64) {
-            !task_ids.contains(&id)
-        } else {
-            true
-        }
-    });
-
-    save_json(&get_file(), &json);
+pub fn init() -> Result<()> {
+    Ok(())
 }
 
-fn edit_task(task_id: u64, inp: String) {
-    let mut json = load_json(&get_file());
-    let tasks = json
-        .get_mut("tasks")
-        .expect("Failed to parse tasks")
-        .as_array_mut()
-        .expect("Failed to parse tasks");
+fn display_task(task: tasks::Task) -> Result<()> {
+    let stdout = stdout();
+    let mut display_handle = BufWriter::new(stdout);
 
-    for task in tasks.iter_mut() {
-        if let Some(id) = task.get("id").and_then(serde_json::Value::as_u64) {
-            if id == task_id {
-                task["text"] = serde_json::json!(inp);
-            }
-        }
+    if task.completed {
+        write!(display_handle, "✓ ")?;
+    } else {
+        write!(display_handle, "✗ ")?;
+    }
+    write!(display_handle, "{} ", task.id)?;
+    write!(display_handle, "{} ", task.text)?;
+    write!(display_handle, "{} ", task.categories.join(", "))?;
+    write!(display_handle, "{} ", task.created_at)?;
+    if task.completed {
+        write!(display_handle, "{} ", task.completed_at.context("completed_at was not set but completed was true")?)?;
     }
 
-    save_json(&get_file(), &json);
-}
+    display_handle.write_all(b"\n")?;
+    display_handle.flush()?;
 
-fn clear_tasks() {
-    let json = serde_json::json!({"tasks": []});
-    save_json(&get_file(), &json);
-}
-
-// get time in a provided format
-fn get_time() -> String {
-    let local: DateTime<Local> = Local::now();
-    local.format("%H:%M %d/%m/%Y").to_string()
+    Ok(())
 }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -1,0 +1,145 @@
+
+use serde_json;
+use std::{
+    collections::HashSet, path::Path, fs::File, io::{BufReader},
+};
+
+use crate::io;
+
+use serde::{Deserialize, Serialize};
+use anyhow::{Result, Context};
+
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Task {
+    pub id: u64,
+    pub text: String,
+    pub categories: Vec<String>,
+    pub created_at: String,
+    pub completed_at: Option<String>,
+    pub completed: bool
+} 
+
+#[derive(Serialize, Deserialize)]
+pub struct Store {
+    pub tasks: Vec<Task>
+}
+
+pub fn load(path: &Path) -> Result<Store> {
+    let file = File::open(&path).context("fs failed to read the file")?;
+    let reader = BufReader::new(file);
+    serde_json::from_reader(reader).context("serde_json failed to read from the file")
+}
+
+pub fn save(filename: &Path, store: Store) -> Result<()> {
+    let file = File::create(filename).with_context(|| format!("fs failed to create file {}", filename.display()))?;
+    let writer = std::io::BufWriter::new(file);
+    serde_json::to_writer_pretty(writer, &store).context("serde_json failed to write to the file")
+}
+
+pub fn get(id: u64) -> Result<Option<Task>> {
+    let store = load(&io::get_datastore_file()?)?;
+
+    let task = store.tasks.iter()
+        .filter(|t| t.id == id)
+        .collect::<Vec<&Task>>()
+        .first()
+        .cloned()
+        .cloned();
+
+    Ok(task)
+}
+
+pub fn get_all(show_all: bool, show_complete: bool, categories: Vec<String>) -> Result<Vec<Task>> {
+    let store = load(&io::get_datastore_file()?)?;
+
+    if show_all {
+        return Ok(store.tasks.clone());
+    }
+
+    if show_complete {
+        return Ok(store.tasks.iter().filter(|t| t.completed).map(|t| t.clone()).collect());
+    }
+
+    let category_set: HashSet<String> = categories.into_iter().collect();
+
+    let filtered_tasks = store.tasks.iter()
+        .filter(|t| {
+            t.categories.iter().any(|c| category_set.contains(c))
+        })
+        .map(|t| t.clone())
+        .collect();
+
+    Ok(filtered_tasks)
+}
+
+pub fn create(text: String, categories: Vec<String>) -> Result<()> {
+    let mut store = load(&io::get_datastore_file()?)?;
+    store.tasks.sort_by(|a, b| a.id.cmp(&b.id));
+    let next_id = store.tasks.last().map_or(0, |task| task.id) + 1;
+
+    let task = Task {
+        id: next_id,
+        text,
+        categories,
+        created_at: io::get_time_string()?,
+        completed_at: None,
+        completed: false,
+    };
+
+    store.tasks.push(task);
+
+    save(&io::get_datastore_file()?, store)
+}
+
+pub fn edit(task_id: u64, inp: String) -> Result<Option<Task>> {
+    let mut store = load(&io::get_datastore_file()?)?;
+    let task = store.tasks.iter_mut().find(|t| t.id == task_id);
+
+    if let Some(mut task) = task {
+        task.text = inp;
+
+        let task = task.clone();
+        save(&io::get_datastore_file()?, store)?;
+
+        Ok(Some(task))
+    }
+    else {
+        Ok(None)
+    }
+}
+
+pub fn reset() -> Result<()> {
+    save(&io::get_datastore_file()?, Store {
+        tasks: vec![]
+    })
+}
+
+pub fn delete(task_ids: Vec<u64>) -> Result<()> {
+    let mut store = load(&io::get_datastore_file()?)?;
+
+    store.tasks.retain(|task| {
+        !task_ids.contains(&task.id)
+    });
+
+    save(&io::get_datastore_file()?, store)
+}
+
+pub fn toggle_completion(id: u64) -> Result<()> {
+    let mut store = load(&io::get_datastore_file()?)?;
+    let task = store.tasks.iter_mut().find(|t| t.id == id);
+
+    if let Some(task) = task {
+        if task.completed {
+            task.completed_at = None;
+        }
+        else {
+            task.completed_at = Some(io::get_time_string()?);
+        }
+        task.completed = !task.completed;
+        save(&io::get_datastore_file()?, store)
+    }
+    else {
+        Ok(())
+    }
+}


### PR DESCRIPTION
This separates out the data CRUD operations into tasks.rs, moves misc io operations into io.rs, refactors main to use these new functions, and adds propagation of errors generally and handling of such errors in main.