### PR TITLE
fix!: use `CARGO_PKG_NAME` to construct path

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -6,7 +6,7 @@ use crate::tasks::Store;
 
 pub fn get_datastore_file() -> Result<PathBuf> {
     let docs_todo = dirs::document_dir().context("document dir could not be found")?.join("todo.json");
-    let local_todo = dirs::data_local_dir().context("data dir could not be found")?.join("belldo/todo.json");
+    let local_todo = dirs::data_local_dir().context("data dir could not be found")?.join(concat!(env!("CARGO_PKG_NAME"), "/todo.json"));
 
     if docs_todo.exists() {
         Ok(docs_todo)


### PR DESCRIPTION
switch to using the `CARGO_PKG_NAME` environment variable that cargo sets during building to construct the path for the datastore file. Avoids duplicating the project name in the `Cargo.toml` and in the code

BREAKING: changes the datastore path from `$data_local_dir/belldo/todo.json` to `$data_local_dir/bellado/todo.json`